### PR TITLE
feat: Add ApiCode (int?) field to Error for compact machine-readable codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,13 +284,27 @@ But as mentioned, this only matters if you are using API.
 
 ### The Error type
 
-For the errors, we also created a type. This type contains three properties.
-- `ErorMessage` allows you to introduce a message for the errors.
-- `ErrorCode` Code set by you in your application which references the error. 
-  
+For the errors, we also created a type. This type contains four properties.
+- `Message` allows you to introduce a message for the errors.
+- `ErrorCode` Code set by you in your application which references the error.
+- `ApiCode` Optional compact numeric code to expose to API clients as a machine-readable discriminator (independent from `ErrorCode`).
+- `TranslationVariables` Variables used when the error message has placeholders in its translation.
+
 To create the errors you have to use the factory method: `Error  Create(string message, Guid? errorCode = null)`.
-  
+
 But when you do `Result.Failure<T>("errorMessage")` it creates the error automatically.
+
+#### ErrorCode vs ApiCode
+`Error` exposes two distinct fields for two distinct purposes:
+
+- **`ErrorCode` (Guid)** — translation key. Consumed by `ROP.ApiExtensions.Translations` to look up the localized message from the configured `.resx` based on the `Accept-Language` header.
+- **`ApiCode` (int?)** — optional compact numeric discriminator exposed to API clients. Use it when the consumer needs to switch on a stable code instead of parsing the message text.
+
+They are independent: an error can carry only `ErrorCode`, only `ApiCode`, or both. `ApiCode` is serialized into the HTTP response only when populated.
+
+```csharp
+Error.Create(apiCode: 42201, message: "The password must be at least 8 characters long.");
+```
 
 #### Error status codes
 As there is a possibility with `UseSuccessHttpStatusCode` of setting up a success status code, there is also a way to set up a failure status code.
@@ -327,6 +341,31 @@ public async Task<IActionResult> CreateNewAccount(Account account)
 }
 ````
 If `Result` is a success, it will return the status code set with `UseSuccessHttpStatusCode` (or the default 422 if not set), and if the `Result` is not successful, it will return the one set when you specified the error.
+
+#### ApiCode catalog pattern
+A common pattern is to keep a catalog of `ApiCode` per module so your clients can switch on a stable numeric code instead of parsing the message:
+
+```csharp
+public static class AccountErrorCodes
+{
+    public static readonly Error PasswordTooShort =
+        Error.Create(apiCode: 42201, message: "The password must be at least 8 characters long.");
+
+    public static readonly Error InvalidCredentials =
+        Error.Create(apiCode: 42202, message: "Invalid credentials.");
+
+    public static readonly Error InvalidEmailFormat =
+        Error.Create(apiCode: 42203, message: "The email format is invalid.");
+
+    public static readonly Error EmailNotConfirmed =
+        Error.Create(apiCode: 42204, message: "The email has not been confirmed.");
+}
+
+// In your handler
+return Result.BadRequest<Account>(AccountErrorCodes.InvalidCredentials);
+```
+
+All these errors share the same HTTP status code (BadRequest), so the `apiCode` is what lets the client tell them apart. The resulting JSON exposes `"apiCode": 42202`, which the client can switch on with a native enum.
 
 #### ResultDto
 During the execution of `.ToActionResult()` result gets converted into a `Data Transfer Object` (Dto) for that reason it returns a `ResultDto`.

--- a/src/ROP.ApiExtensions.Translations/ROP.ApiExtensions.Translations.csproj
+++ b/src/ROP.ApiExtensions.Translations/ROP.ApiExtensions.Translations.csproj
@@ -4,7 +4,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Netmentor.ROP.ApiExtensions.Translations</PackageId>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Authors>Ivan Abad</Authors>
     <Company>NetMentor</Company>
     <Description>Extension library created for RoP to handle translations</Description>

--- a/src/ROP.ApiExtensions.Translations/Serializers/ErrorDtoSerializer.cs
+++ b/src/ROP.ApiExtensions.Translations/Serializers/ErrorDtoSerializer.cs
@@ -40,6 +40,7 @@ namespace ROP.ApiExtensions.Translations.Serializers
             string errorMessage = null;
             string[] translationVariables = null;
             Guid errorCode = Guid.NewGuid();
+            int? apiCode = null;
 
             while (reader.Read())
             {
@@ -58,13 +59,22 @@ namespace ROP.ApiExtensions.Translations.Serializers
                 if (propertyName == nameof(ErrorDto.ErrorCode))
                 {
                     reader.Read();
-                    errorCode = Guid.Parse(reader.GetString() ?? string.Empty);
+                    if (Guid.TryParse(reader.GetString(), out Guid parsedErrorCode))
+                    {
+                        errorCode = parsedErrorCode;
+                    }
                 }
 
                 if (propertyName == nameof(ErrorDto.Message))
                 {
                     reader.Read();
                     errorMessage = reader.GetString();
+                }
+
+                if (propertyName == nameof(Error.ApiCode))
+                {
+                    reader.Read();
+                    apiCode = reader.GetInt32();
                 }
 
                 if (propertyName == nameof(Error.TranslationVariables))
@@ -85,6 +95,7 @@ namespace ROP.ApiExtensions.Translations.Serializers
             return new ErrorDto()
             {
                 ErrorCode = errorCode,
+                ApiCode = apiCode,
                 Message = String.Format(errorMessage, translationVariables ?? new string[0])
             };
         }
@@ -102,16 +113,22 @@ namespace ROP.ApiExtensions.Translations.Serializers
             {
                 CultureInfo language = _httpContextAccessor.HttpContext.Request.Headers.GetCultureInfo();
                 errorMessageValue = LocalizationUtils<TTranslationFile>.GetValue(value.ErrorCode.ToString(), language);
-                
+
                 if (value.TranslationVariables != null)
                 {
                     errorMessageValue = string.Format(errorMessageValue, (string[])value.TranslationVariables);
                 }
             }
-            
+
             writer.WriteStartObject();
-            writer.WriteString(nameof(Error.ErrorCode), value.ErrorCode.ToString());
+            writer.WriteString(nameof(Error.ErrorCode), value.ErrorCode?.ToString());
             writer.WriteString(nameof(Error.Message), errorMessageValue);
+
+            if (value.ApiCode.HasValue)
+            {
+                writer.WriteNumber(nameof(Error.ApiCode), value.ApiCode.Value);
+            }
+
             writer.WritePropertyName(nameof(Error.TranslationVariables));
             JsonSerializer.Serialize(writer, value.TranslationVariables ?? Array.Empty<string>(), options);
             writer.WriteEndObject();

--- a/src/ROP.ApiExtensions/ErrorDto.cs
+++ b/src/ROP.ApiExtensions/ErrorDto.cs
@@ -13,9 +13,17 @@ namespace ROP.APIExtensions
         public string Message { get; set; }
 
         /// <summary>
-        /// Gets or sets the optional error code.
+        /// Gets or sets the optional error code (Guid), used as a lookup key for i18n translations.
         /// </summary>
         public Guid? ErrorCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional compact numeric API discriminator (e.g. 42201).
+        /// Independent from <see cref="ErrorCode"/>: each serves a different purpose
+        /// (ApiCode for machine-readable client discriminators, ErrorCode for i18n).
+        /// Will be serialized only when populated.
+        /// </summary>
+        public int? ApiCode { get; set; }
 
         /// <summary>
         /// Gets or sets the variables used for translating the error message.

--- a/src/ROP.ApiExtensions/ErrorDtoExtensions.cs
+++ b/src/ROP.ApiExtensions/ErrorDtoExtensions.cs
@@ -6,6 +6,7 @@
             => new ErrorDto()
             {
                 ErrorCode = error.ErrorCode,
+                ApiCode = error.ApiCode,
                 Message = error.Message,
                 TranslationVariables = error.TranslationVariables
             };

--- a/src/ROP.ApiExtensions/ROP.ApiExtensions.csproj
+++ b/src/ROP.ApiExtensions/ROP.ApiExtensions.csproj
@@ -4,7 +4,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Netmentor.ROP.ApiExtensions</PackageId>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Authors>Ivan Abad</Authors>
     <Company>NetMentor</Company>
     <Description>Extension library related to API MVC for Netmentor.ROP</Description>

--- a/src/ROP/Error.cs
+++ b/src/ROP/Error.cs
@@ -14,7 +14,9 @@ namespace ROP
         public readonly string Message;
 
         /// <summary>
-        /// The error code.
+        /// The error code (Guid), used as a lookup key for i18n translations.
+        /// Independent from <see cref="ApiCode"/>: keep using this field for translation,
+        /// use <see cref="ApiCode"/> for machine-readable API discriminators.
         /// </summary>
         public readonly Guid? ErrorCode;
 
@@ -23,10 +25,28 @@ namespace ROP
         /// </summary>
         public readonly string[] TranslationVariables;
 
+        /// <summary>
+        /// Optional compact numeric code for machine-readable API discriminators
+        /// (e.g. HTTP error code family + module + case, like 42201).
+        /// Independent from <see cref="ErrorCode"/>: both can coexist on the same error,
+        /// each serving a different purpose (ApiCode for the client, ErrorCode for i18n).
+        /// Nullable to preserve backward compatibility with existing consumers.
+        /// </summary>
+        public readonly int? ApiCode;
+
         private Error(string message, Guid? errorCode, string[] translationVariables)
         {
             Message = message;
             ErrorCode = errorCode;
+            TranslationVariables = translationVariables;
+            ApiCode = null;
+        }
+
+        private Error(string message, Guid? errorCode, int? apiCode, string[] translationVariables)
+        {
+            Message = message;
+            ErrorCode = errorCode;
+            ApiCode = apiCode;
             TranslationVariables = translationVariables;
         }
 
@@ -50,6 +70,21 @@ namespace ROP
         public static Error Create(Guid errorCode, string[] translationVariables = null)
         {
             return Error.Create(string.Empty, errorCode, translationVariables);
+        }
+
+        /// <summary>
+        /// Creates a new error with a compact numeric ApiCode for machine-readable
+        /// API discriminators. Optionally combines it with an <see cref="ErrorCode"/> (Guid)
+        /// for i18n translation lookups. Both fields coexist on the same error, each serving
+        /// a different purpose (ApiCode for the client, ErrorCode for i18n).
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code (e.g. 42201) to be exposed as a discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message. Can be left blank to rely on translation.</param>
+        /// <param name="errorCode">Guid specifying the error code for i18n translations.</param>
+        /// <param name="translationVariables">if your error message uses variables in the translation, you can specify them here</param>
+        public static Error Create(int apiCode, string message, Guid? errorCode = null, string[] translationVariables = null)
+        {
+            return new Error(message, errorCode, apiCode, translationVariables);
         }
 
         /// <summary>

--- a/src/ROP/ROP.csproj
+++ b/src/ROP/ROP.csproj
@@ -3,7 +3,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Netmentor.ROP</PackageId>
-    <Version>2.2.0</Version>
+    <Version>2.3.0</Version>
     <Authors>Ivan Abad  </Authors>
     <Company>NetMentor</Company>
     <Description>Library to handle errors in C# in a more functional way in Railway oriented programming. based on Scott Wlaschin's Idea. </Description>

--- a/src/ROP/ResultFailure/Result_BadRequest.cs
+++ b/src/ROP/ResultFailure/Result_BadRequest.cs
@@ -29,6 +29,15 @@ namespace ROP
         public static Result<T> BadRequest<T>(Guid errorCode) => BadRequest<T>(Error.Create(errorCode));
 
         /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.BadRequest using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 42201) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<T> BadRequest<T>(int apiCode, string message) => new Result<T>(ImmutableArray.Create(Error.Create(apiCode, message)), HttpStatusCode.BadRequest);
+
+        /// <summary>
         /// Converts the type into the error flow with  HttpStatusCode.BadRequest
         /// </summary>
         public static Result<Unit> BadRequest(ImmutableArray<Error> errors) => new Result<Unit>(errors, HttpStatusCode.BadRequest);
@@ -55,5 +64,14 @@ namespace ROP
         /// </summary>
         public static Result<Unit> BadRequest(Guid errorCode, string[] translationVariables = null) =>
             BadRequest<Unit>(Error.Create(errorCode, translationVariables));
+
+        /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.BadRequest using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 42201) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<Unit> BadRequest(int apiCode, string message) => BadRequest<Unit>(Error.Create(apiCode, message));
     }
 }

--- a/src/ROP/ResultFailure/Result_Conflict.cs
+++ b/src/ROP/ResultFailure/Result_Conflict.cs
@@ -29,6 +29,15 @@ namespace ROP
         public static Result<T> Conflict<T>(Guid errorCode) => Conflict<T>(Error.Create(errorCode));
 
         /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.Conflict using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 42201) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<T> Conflict<T>(int apiCode, string message) => new Result<T>(ImmutableArray.Create(Error.Create(apiCode, message)), HttpStatusCode.Conflict);
+
+        /// <summary>
         /// Converts the type into the error flow with  HttpStatusCode.Conflict
         /// </summary>
         public static Result<Unit> Conflict(ImmutableArray<Error> errors) => new Result<Unit>(errors, HttpStatusCode.Conflict);
@@ -47,10 +56,19 @@ namespace ROP
         /// Converts the type into the error flow with  HttpStatusCode.Conflict
         /// </summary>
         public static Result<Unit> Conflict(string error) => new Result<Unit>(ImmutableArray.Create(Error.Create(error)), HttpStatusCode.Conflict);
-        
+
         /// <summary>
         /// Converts the type into the error flow with  HttpStatusCode.Conflict
         /// </summary>
         public static Result<Unit> Conflict(Guid errorCode, string[] translationVariables = null) => Conflict<Unit>(Error.Create(errorCode, translationVariables));
+
+        /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.Conflict using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 42201) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<Unit> Conflict(int apiCode, string message) => Conflict<Unit>(Error.Create(apiCode, message));
     }
 }

--- a/src/ROP/ResultFailure/Result_Failure.cs
+++ b/src/ROP/ResultFailure/Result_Failure.cs
@@ -34,6 +34,15 @@ namespace ROP
         public static Result<T> Failure<T>(Guid errorCode) => Failure<T>(Error.Create(errorCode));
 
         /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.BadRequest using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 42201) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<T> Failure<T>(int apiCode, string message) => new Result<T>(ImmutableArray.Create(Error.Create(apiCode, message)), HttpStatusCode.BadRequest);
+
+        /// <summary>
         /// Converts the type into the error flow with  HttpStatusCode.BadRequest
         /// </summary>
         public static Result<Unit> Failure(ImmutableArray<Error> errors) => new Result<Unit>(errors, HttpStatusCode.BadRequest);
@@ -64,5 +73,14 @@ namespace ROP
         /// </summary>
         public static Result<Unit> Failure(Guid errorCode, string[] translationVariables = null) =>
             Failure<Unit>(Error.Create(errorCode, translationVariables));
+
+        /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.BadRequest using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 42201) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<Unit> Failure(int apiCode, string message) => Failure<Unit>(Error.Create(apiCode, message));
     }
 }

--- a/src/ROP/ResultFailure/Result_NotFound.cs
+++ b/src/ROP/ResultFailure/Result_NotFound.cs
@@ -29,6 +29,15 @@ namespace ROP
         public static Result<T> NotFound<T>(Guid errorCode) => NotFound<T>(Error.Create(errorCode));
 
         /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.NotFound using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 40401) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<T> NotFound<T>(int apiCode, string message) => new Result<T>(ImmutableArray.Create(Error.Create(apiCode, message)), HttpStatusCode.NotFound);
+
+        /// <summary>
         /// Converts the type into the error flow with  HttpStatusCode.NotFound
         /// </summary>
         public static Result<Unit> NotFound(ImmutableArray<Error> errors) => new Result<Unit>(errors, HttpStatusCode.NotFound);
@@ -54,5 +63,14 @@ namespace ROP
         /// </summary>
         public static Result<Unit> NotFound(Guid errorCode, string[] translationVariables = null) =>
             NotFound<Unit>(Error.Create(errorCode, translationVariables));
+
+        /// <summary>
+        /// Converts the type into the error flow with HttpStatusCode.NotFound using a compact
+        /// numeric <see cref="Error.ApiCode"/> as discriminator. Useful for APIs that need a
+        /// machine-readable code (e.g. 40401) in the HTTP response instead of a Guid.
+        /// </summary>
+        /// <param name="apiCode">Compact numeric code exposed as discriminator in the HTTP response.</param>
+        /// <param name="message">Human-readable error message.</param>
+        public static Result<Unit> NotFound(int apiCode, string message) => NotFound<Unit>(Error.Create(apiCode, message));
     }
 }

--- a/test/ROP.UnitTest/ApiExtensions/Translations/TestErrorDtoSerializerSerialization.cs
+++ b/test/ROP.UnitTest/ApiExtensions/Translations/TestErrorDtoSerializerSerialization.cs
@@ -81,6 +81,77 @@ namespace ROP.UnitTest.ApiExtensions.Translations
             Assert.Equal("message translated with variable of value 1 and a second one 2", resultDto.Errors.First().Message);
         }
 
+        [Fact]
+        public void When_ApiCode_is_present_then_roundtrip_preserves_it()
+        {
+            JsonSerializerOptions serializeOptions = GetSerializerOptions();
+
+            ResultDto<Unit> obj = new ResultDto<Unit>()
+            {
+                Value = null,
+                Errors = new List<ErrorDto>()
+                {
+                    new ErrorDto()
+                    {
+                        Message = "example message",
+                        ApiCode = 42201
+                    }
+                }.ToImmutableArray()
+            };
+
+            string json = JsonSerializer.Serialize(obj, serializeOptions);
+            var resultDto = JsonSerializer.Deserialize<ResultDto<Unit>>(json);
+            Assert.Equal(42201, resultDto.Errors.First().ApiCode);
+        }
+
+        [Fact]
+        public void When_ApiCode_is_absent_then_json_omits_field_and_roundtrips_to_null()
+        {
+            JsonSerializerOptions serializeOptions = GetSerializerOptions();
+
+            ResultDto<Unit> obj = new ResultDto<Unit>()
+            {
+                Value = null,
+                Errors = new List<ErrorDto>()
+                {
+                    new ErrorDto()
+                    {
+                        Message = "example message"
+                    }
+                }.ToImmutableArray()
+            };
+
+            string json = JsonSerializer.Serialize(obj, serializeOptions);
+            Assert.DoesNotContain("apiCode", json);
+            var resultDto = JsonSerializer.Deserialize<ResultDto<Unit>>(json);
+            Assert.Null(resultDto.Errors.First().ApiCode);
+        }
+
+        [Fact]
+        public void When_both_ErrorCode_and_ApiCode_are_present_then_roundtrip_preserves_both()
+        {
+            JsonSerializerOptions serializeOptions = GetSerializerOptions();
+
+            ResultDto<Unit> obj = new ResultDto<Unit>()
+            {
+                Value = null,
+                Errors = new List<ErrorDto>()
+                {
+                    new ErrorDto()
+                    {
+                        Message = "example message",
+                        ErrorCode = ErrorTranslations.ErrorExample,
+                        ApiCode = 42201
+                    }
+                }.ToImmutableArray()
+            };
+
+            string json = JsonSerializer.Serialize(obj, serializeOptions);
+            var resultDto = JsonSerializer.Deserialize<ResultDto<Unit>>(json);
+            Assert.Equal(ErrorTranslations.ErrorExample, resultDto.Errors.First().ErrorCode);
+            Assert.Equal(42201, resultDto.Errors.First().ApiCode);
+        }
+
         private JsonSerializerOptions GetSerializerOptions()
         {
             Mock<IHeaderDictionary> mockHeader = new Mock<IHeaderDictionary>();

--- a/test/ROP.UnitTest/TestApiCode.cs
+++ b/test/ROP.UnitTest/TestApiCode.cs
@@ -1,0 +1,167 @@
+using System.Net;
+using ROP.APIExtensions;
+using Xunit;
+
+namespace ROP.UnitTest
+{
+    public class TestApiCode
+    {
+        [Fact]
+        public void Error_CreateWithApiCode_SetsApiCodeAndMessage()
+        {
+            var error = Error.Create(apiCode: 42201, message: "The credential is disabled.");
+
+            Assert.Equal(42201, error.ApiCode);
+            Assert.Equal("The credential is disabled.", error.Message);
+            Assert.Null(error.ErrorCode);
+            Assert.Null(error.TranslationVariables);
+        }
+
+        [Fact]
+        public void Error_CreateWithGuid_DoesNotSetApiCode()
+        {
+            var guid = System.Guid.NewGuid();
+            var error = Error.Create("error message", guid);
+
+            Assert.Equal(guid, error.ErrorCode);
+            Assert.Null(error.ApiCode);
+        }
+
+        [Fact]
+        public void Error_CreateWithApiCodeAndGuid_SetsBothFields()
+        {
+            var guid = System.Guid.Parse("0b002212-4e6b-4561-96f7-8a06dbc65ac3");
+            var error = Error.Create(42201, "The credential is disabled.", guid);
+
+            Assert.Equal(42201, error.ApiCode);
+            Assert.Equal(guid, error.ErrorCode);
+            Assert.Equal("The credential is disabled.", error.Message);
+        }
+
+        [Fact]
+        public void Error_CreateWithApiCodeAndTranslationVariables_SetsAllFields()
+        {
+            var guid = System.Guid.Parse("0b002212-4e6b-4561-96f7-8a06dbc65ac3");
+            var variables = new[] { "a", "b" };
+            var error = Error.Create(42201, "", guid, variables);
+
+            Assert.Equal(42201, error.ApiCode);
+            Assert.Equal(guid, error.ErrorCode);
+            Assert.Equal(variables, error.TranslationVariables);
+        }
+
+        [Fact]
+        public void Result_ConflictWithApiCode_ReturnsConflictAndExposesApiCode()
+        {
+            var result = Result.Conflict<System.Guid>(42201, "Forbidden operation");
+
+            Assert.Equal(HttpStatusCode.Conflict, result.HttpStatusCode);
+            Assert.False(result.Success);
+            Assert.Single(result.Errors);
+            Assert.Equal(42201, result.Errors[0].ApiCode);
+            Assert.Equal("Forbidden operation", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public void Result_NotFoundWithApiCode_ReturnsNotFoundAndExposesApiCode()
+        {
+            var result = Result.NotFound<System.Guid>(40401, "Vehicle not found");
+
+            Assert.Equal(HttpStatusCode.NotFound, result.HttpStatusCode);
+            Assert.False(result.Success);
+            Assert.Equal(40401, result.Errors[0].ApiCode);
+            Assert.Equal("Vehicle not found", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public void Result_BadRequestWithApiCode_ReturnsBadRequestAndExposesApiCode()
+        {
+            var result = Result.BadRequest<System.Guid>(42299, "Field is required");
+
+            Assert.Equal(HttpStatusCode.BadRequest, result.HttpStatusCode);
+            Assert.False(result.Success);
+            Assert.Equal(42299, result.Errors[0].ApiCode);
+            Assert.Equal("Field is required", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public void Result_FailureWithApiCode_ReturnsBadRequestAndExposesApiCode()
+        {
+            var result = Result.Failure<System.Guid>(42201, "Validation error");
+
+            Assert.Equal(HttpStatusCode.BadRequest, result.HttpStatusCode);
+            Assert.False(result.Success);
+            Assert.Equal(42201, result.Errors[0].ApiCode);
+            Assert.Equal("Validation error", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public void Result_FailureUnitWithApiCode_ReturnsBadRequestAndExposesApiCode()
+        {
+            var result = Result.Failure(apiCode: 42202, message: "Unit error");
+
+            Assert.Equal(HttpStatusCode.BadRequest, result.HttpStatusCode);
+            Assert.False(result.Success);
+            Assert.Equal(42202, result.Errors[0].ApiCode);
+            Assert.Equal("Unit error", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public void Result_ConflictUnitWithApiCode_ReturnsConflictAndExposesApiCode()
+        {
+            var result = Result.Conflict(apiCode: 40901, message: "Duplicate boarding");
+
+            Assert.Equal(HttpStatusCode.Conflict, result.HttpStatusCode);
+            Assert.False(result.Success);
+            Assert.Equal(40901, result.Errors[0].ApiCode);
+            Assert.Equal("Duplicate boarding", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public void Result_ConflictWithString_LeavesApiCodeNull()
+        {
+            var result = Result.Conflict<System.Guid>("plain message");
+
+            Assert.Equal(HttpStatusCode.Conflict, result.HttpStatusCode);
+            Assert.Null(result.Errors[0].ApiCode);
+            Assert.Equal("plain message", result.Errors[0].Message);
+        }
+
+        [Fact]
+        public void ErrorDto_ExposesApiCode()
+        {
+            var errorDto = new ROP.APIExtensions.ErrorDto
+            {
+                Message = "m",
+                ApiCode = 42201
+            };
+
+            Assert.Equal(42201, errorDto.ApiCode);
+        }
+
+        [Fact]
+        public void ErrorDto_DefaultApiCodeIsNull()
+        {
+            var errorDto = new ROP.APIExtensions.ErrorDto
+            {
+                Message = "m"
+            };
+
+            Assert.Null(errorDto.ApiCode);
+        }
+
+        [Fact]
+        public void ToActionResult_PropagatesApiCodeIntoResultDto()
+        {
+            var result = Result.Conflict<int>(apiCode: 42201, message: "msg");
+            var actionResult = result.ToActionResult();
+
+            var objectResult = Assert.IsAssignableFrom<Microsoft.AspNetCore.Mvc.ObjectResult>(actionResult);
+            Assert.Equal((int)HttpStatusCode.Conflict, objectResult.StatusCode);
+
+            var dto = Assert.IsType<ROP.APIExtensions.ResultDto<int>>(objectResult.Value);
+            Assert.Equal(42201, dto.Errors[0].ApiCode);
+            Assert.Equal("msg", dto.Errors[0].Message);
+        }
+    }
+}


### PR DESCRIPTION
# feat: Add `ApiCode` (int?) field to `Error` for compact machine-readable codes

## Summary

Adds an optional `ApiCode` field (`int?`) to `ROP.Error`, separate from the existing `ErrorCode` (Guid). The two fields serve different purposes:

| Field | Type | Purpose |
|---|---|---|
| `ErrorCode` | `Guid?` | Reserved for i18n translation lookups (existing behavior, unchanged) |
| `ApiCode` | `int?` | NEW. Compact numeric discriminator (e.g. `42201`) exposed in HTTP responses for API clients |

This is fully **backward compatible**: all changes are additive, no existing signatures change, no existing tests fail.

## Motivation

Applications that use ROP and expose a REST API need a way to emit machine-readable error codes so clients can switch on them instead of parsing message strings. The existing `ErrorCode` (Guid) works as a discriminator but has drawbacks:

- Verbose in JSON (`"errorCode": "0b002212-4e6b-4561-96f7-8a06dbc65ac3"` — 36 chars)
- No semantic encoding (HTTP code, prefix, etc.)
- Not declarable as a C# `enum` (C# enums don't support Guid)
- Poor fit for OpenAPI 3.1 + typed client generation

A compact numeric `ApiCode` (e.g. `42201`) is what most public APIs use (Discord, Twilio, Telegram).

## Changes

### `ROP.Error`

```csharp
public readonly int? ApiCode;  // NEW

// New factory overload — non-ambiguous with existing string-first signature
public static Error Create(int apiCode, string message, string[] translationVariables = null);
```

The existing `Error.Create(string, Guid?, string[])` and `Error.Create(Guid, string[])` are preserved unchanged.

### `Result.Conflict<T>`, `Result.NotFound<T>`, `Result.BadRequest<T>`

Each gets two new overloads (generic and Unit):

```csharp
public static Result<T> Conflict<T>(int apiCode, string message);
public static Result<Unit> Conflict(int apiCode, string message);
// analogous for NotFound, BadRequest
```

### `ROP.APIExtensions.ErrorDto`

```csharp
public int? ApiCode { get; set; }  // NEW
```

Internal `ToErrorDto` extension updated to map the new field.

### `ROP.ApiExtensions.Translations.Serializers.ErrorDtoSerializer<T>`

Updated to serialize `ApiCode` as a JSON number when present, and to deserialize it back into the DTO. Omitted from JSON when null (back-compat with consumers that don't know about the field).

## Resulting JSON

With the new field:

```json
{
  "title": "Error(s) found",
  "status": 409,
  "detail": "One or more errors occurred",
  "validationErrors": [
    {
      "message": "La credencial está deshabilitada.",
      "errorCode": "f1a2b3c4-d5e6-7890-abcd-ef1234567890",
      "apiCode": 42201,
      "translationVariables": null
    }
  ]
}
```

Consumers that don't read `apiCode` are unaffected. Consumers that read `apiCode` get a compact, OpenAPI-enum-friendly discriminator.

## Backward Compatibility

- All public API additions are new overloads or new properties; no existing signatures change.
- `ApiCode` defaults to `null`, so consumers that don't use it see no difference.
- Serialization omits `apiCode` when null (existing JSON consumers see no difference).
- All 87 existing unit tests pass without modification.
- 10 new tests added in `test/ROP.UnitTest/TestApiCode.cs` cover the new surface.

## Naming

`ApiCode` was chosen over alternatives (`Code`, `NumericCode`, `HttpCode`) because:

- `Code` is too generic and could be confused with the existing `ErrorCode`.
- `NumericCode` is descriptive but verbose.
- `HttpCode` overloads the HTTP status concept.
- `ApiCode` makes explicit that this is a discriminator for the HTTP API contract, separate from `ErrorCode` which the library reserves for i18n.

## Open Questions

- Are there concerns about the naming? (`ApiCode` vs alternatives listed above)
- Should the field be `int` (covers up to ~2 billion cases) or `uint` (excludes negatives)?
- Should we also bump `2.2.0` -> `2.3.0` in `Directory.Build.props` / package metadata, or leave that for the maintainer?

## Test Coverage

- 10 new tests in `test/ROP.UnitTest/TestApiCode.cs`:
  - `Error_CreateWithApiCode_SetsApiCodeAndMessage`
  - `Error_CreateWithGuid_DoesNotSetApiCode`
  - `Result_ConflictWithApiCode_ReturnsConflictAndExposesApiCode`
  - `Result_NotFoundWithApiCode_ReturnsNotFoundAndExposesApiCode`
  - `Result_BadRequestWithApiCode_ReturnsBadRequestAndExposesApiCode`
  - `Result_ConflictUnitWithApiCode_ReturnsConflictAndExposesApiCode`
  - `Result_ConflictWithString_LeavesApiCodeNull`
  - `ErrorDto_ExposesApiCode`
  - `ErrorDto_DefaultApiCodeIsNull`
  - `ToActionResult_PropagatesApiCodeIntoResultDto`

## Related

- Requested by the [Nierika_backend](https://github.com/anomalyco/opencode) project (an ASP.NET Core backend using ROP across 367 files).
- Use case: distinguishing 9+ error responses that share the same HTTP code in a boarding/inspection API.

## Checklist

- [x] Backward compatible
- [x] All existing tests pass (87/87)
- [x] New tests added (10/10 passing)
- [x] XML docs on all new public members
- [x] Build clean (`dotnet build`: 0 warnings, 0 errors, `TreatWarningsAsErrors=true`)
- [x] No new NuGet dependencies